### PR TITLE
Use Zeromq

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The payload of the message. These values vary per message type.
 
 An example message might look like this:
 ```JSON
-“login {
+“login": {
    "timestamp":1507214081.483756,
    "rfid":"0x1234567",
    "machine_id":4567,
@@ -39,7 +39,7 @@ An example message might look like this:
       "height":182
    },
    "machine_type":"M18"
-}”
+}
 ```
 All messages are of the form *“<message_type> <message_body>”*.
 
@@ -65,13 +65,13 @@ Emitted when a user logs out.
 
 **Payload:** `null`
 
-    "logout {
+    "logout": {
        "timestamp":1507282654.697113,
        "rfid":"0x1234567",
        "machine_id":4567,
        "payload":null,
        "machine_type":"M18"
-    }"
+    }
 
 #### trainer_needed
 Emitted when a user has logged in, but doesn’t have settings for that particular machine yet.
@@ -81,7 +81,7 @@ Emitted when a user has logged in, but doesn’t have settings for that particul
 #### start_training
 Emitted when a user starts a training.
 
-    "start_training {
+    "start_training": {
        "timestamp":1507278857.209818,
        "rfid":"0x1234567",
        "machine_id":4567,
@@ -92,7 +92,7 @@ Emitted when a user starts a training.
           "number_of_repetitions":8
        },
        "machine_type":"M18"
-    }"
+    }
 
 **Payload:** JSON object with keys
 * **training_method**
@@ -107,7 +107,7 @@ number, recommended number of repetitions for the training
 #### end_training
 Emitted when a user ends the training.
 
-    "end_training {
+    "end_training": {
        "timestamp":1507283268.229535,
        "rfid":"0x1234567",
        "machine_id":4567,
@@ -115,7 +115,7 @@ Emitted when a user ends the training.
           "moved_weight":480
        },
        "machine_type":"M18"
-    }"
+    }
 
 **Payload:** JSON object with keys
 * **moved_weight**
@@ -124,20 +124,20 @@ number, the weight moved during the training in kilograms
 #### start_strength_measurement
 Emitted when a user starts a strength measurement.
 
-    "start_strength_measurement {
+    "start_strength_measurement": {
        "timestamp":1507283268.229615,
        "rfid":"0x1234567",
        "machine_id":4567,
        "payload":"null,
        "machine_type":"M18"
-    }"
+    }
 
 **Payload:** `null`
 
 #### end_strength_measurement
 Emitted when a user accepts a strength measurement.
 
-    "end_strength_measurement {
+    "end_strength_measurement": {
        "timestamp":1507283268.229639,
        "rfid":"0x1234567",
        "machine_id":4567,
@@ -145,7 +145,7 @@ Emitted when a user accepts a strength measurement.
           "weight":275
        },
        "machine_type":"M18"
-    }"
+    }
 
 **Payload:**  JSON object with keys
 * **weight**
@@ -154,7 +154,7 @@ number, the result of the strength measurement in kilograms
 #### training_position_data
 Emitted every 100ms during a training session.
 
-    "training_position_data {
+    "training_position_data": {
        "timestamp":1507283268.229425,
        "rfid":"0x1234567",
        "machine_id":4567,
@@ -162,7 +162,7 @@ Emitted every 100ms during a training session.
           "position":0.75
        },
        "machine_type":"M18"
-    }"
+    }
 
 **Payload:** JSON object with keys
 * **position**
@@ -174,7 +174,7 @@ Emitted every 100ms during a training session. Most interesting for isokinetic t
 the weight during repetitions, but can also be used to detect changes in weight due to a user clicking on the 
 respective button.
 
-    "training_weight_data {
+    "training_weight_data": {
        "timestamp":1507283268.229454,
        "rfid":"0x1234567",
        "machine_id":4567,
@@ -182,7 +182,7 @@ respective button.
           "weight":65
        },
        "machine_type":"M18"
-    }"
+    }
 
 **Payload:** JSON object with keys
 * **weight** number. The current training weight in kg. 
@@ -190,7 +190,7 @@ respective button.
 #### training_direction_data
 Emitted every time the training direction changes during training
 
-    "training_direction_data {
+    "training_direction_data": {
        "timestamp":1507283268.22948,
        "rfid":"0x1234567",
        "machine_id":4567,
@@ -198,7 +198,7 @@ Emitted every time the training direction changes during training
           "direction":"concentric"
        },
        "machine_type":"M18"
-    }"
+    }
 
 **Payload:** JSON object with keys
 * **direction** string. Either “concentric” or “excentric”. 
@@ -206,7 +206,7 @@ Emitted every time the training direction changes during training
 #### training_repetition_data
 Emitted every time the user completes a repetition during training.
 
-    "training_repetition_data {
+    "training_repetition_data": {
        "timestamp":1507283268.229506,
        "rfid":"0x1234567",
        "machine_id":4567,
@@ -214,7 +214,7 @@ Emitted every time the user completes a repetition during training.
           "repetition":3
        },
        "machine_type":"M18"
-    }"
+    }
 
 
 **Payload:** JSON object with keys

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -1,0 +1,13 @@
+# Java client
+
+## Building
+
+```
+$ ./gradlew build
+```
+
+## Running
+
+```
+$ ./gradlew run
+```

--- a/clients/java/build.gradle
+++ b/clients/java/build.gradle
@@ -2,6 +2,7 @@ group 'de.egym'
 version '1.0-SNAPSHOT'
 
 apply plugin: 'java'
+apply plugin: 'application'
 
 sourceCompatibility = 1.8
 
@@ -14,3 +15,7 @@ dependencies {
 
     compile group: 'org.zeromq', name: 'jeromq', version: '0.4.2'
 }
+
+// The application plugin uses this,
+// for the run task.
+mainClassName = "de.egym.Application"

--- a/clients/java/src/main/java/de/egym/Application.java
+++ b/clients/java/src/main/java/de/egym/Application.java
@@ -10,7 +10,7 @@ import org.zeromq.ZMQ;
 
 public final class Application {
 
-	private static final String HOST = "tcp://35.195.199.160:5556";
+	private static final String HOST = "tcp://35.189.246.57:5556";
 
 	private Application() {
 

--- a/clients/java/src/main/java/de/egym/Application.java
+++ b/clients/java/src/main/java/de/egym/Application.java
@@ -28,10 +28,11 @@ public final class Application {
 
 	private void processEvents(final ZMQ.Socket socket) {
 		while (true) {
-			final String[] data = socket.recvStr().split(" ", 2);
-			final String topic = data[0];
-			final String payload = data[1];
-			System.out.println(topic + ", " + payload);
+			final String data = socket.recvStr();
+
+                        // TODO: Use a JSON parser to get the message_type and the body.
+
+			System.out.println(data);
 		}
 	}
 

--- a/clients/javascript/index.html
+++ b/clients/javascript/index.html
@@ -40,10 +40,10 @@
 
     websocket.onmessage = function (e) {
         console.log("Data Received: " + e.data);
-        var message = splitData(e.data);
-        switch (message.command) {
+        var message = JSON.parse(e.data);
+        switch (message.message_type) {
             case "training_position_data":
-                position = message.object.payload.position;
+                position = message.body.payload.position;
                 break;
         }
     }
@@ -51,12 +51,6 @@
     websocket.onopen = function () {
         console.log('Websocket open');
     };
-    function splitData(data) {
-        return {
-            'command': data.substr(0, data.indexOf(" ")),
-            'object': JSON.parse(data.substr(data.indexOf(" ")))
-        };
-    }
 </script>
 
 </body>

--- a/clients/python/consumer.py
+++ b/clients/python/consumer.py
@@ -1,4 +1,5 @@
 import zmq
+import json
 
 
 def subscribe(host):
@@ -11,17 +12,10 @@ def subscribe_with_filter(host, topic_filter):
     subscriber.connect(host)
     return subscriber
 
-
-def await_and_consume(subscriber, handlers):
+def await_and_consume(subscriber):
     while True:
-        (type, data) = subscriber.recv_string().split(' ', 1)
-        handler = handlers.get(type, None)
-        if handler:
-            handler(data)
+        msg = subscriber.recv()
+        obj = json.loads(msg)
+        print(obj)
 
-
-def login_topic_handler(data):
-    print("Login with data: {}".format(data))
-
-
-await_and_consume(subscribe("tcp://35.189.246.57:5556"), {'hello': hello_topic_handler})
+await_and_consume(subscribe("tcp://35.189.246.57:5556"))

--- a/clients/python/consumer.py
+++ b/clients/python/consumer.py
@@ -12,13 +12,25 @@ def subscribe_with_filter(host, topic_filter):
     subscriber.connect(host)
     return subscriber
 
-def await_and_consume(subscriber):
+def await_and_consume(subscriber, handlers):
     while True:
         msg = subscriber.recv()
         try:
             obj = json.loads(msg)
-            print(obj)
+            # print(obj)
+
+            message_type = obj['message_type']
+            handler = handlers.get(message_type, None)
+            if handler:
+                handler(obj['body'])
+            else:
+                print('No handler for message type: ' + message_type)
+
         except ValueError:
             print('Failed to parse JSON: ' + msg)
 
-await_and_consume(subscribe("tcp://35.189.246.57:5556"))
+def login_topic_handler(data):
+        print("Login with data: {}".format(data))
+
+
+await_and_consume(subscribe("tcp://35.189.246.57:5556"), {'login': login_topic_handler})

--- a/clients/python/consumer.py
+++ b/clients/python/consumer.py
@@ -15,7 +15,10 @@ def subscribe_with_filter(host, topic_filter):
 def await_and_consume(subscriber):
     while True:
         msg = subscriber.recv()
-        obj = json.loads(msg)
-        print(obj)
+        try:
+            obj = json.loads(msg)
+            print(obj)
+        except ValueError:
+            print('Failed to parse JSON: ' + msg)
 
 await_and_consume(subscribe("tcp://35.189.246.57:5556"))

--- a/clients/python/consumer.py
+++ b/clients/python/consumer.py
@@ -24,4 +24,4 @@ def login_topic_handler(data):
     print("Login with data: {}".format(data))
 
 
-await_and_consume(subscribe("tcp://35.195.199.160:5556"), {'login': login_topic_handler})
+await_and_consume(subscribe("tcp://35.189.246.57:5556"), {'hello': hello_topic_handler})

--- a/server/README_deploy.md
+++ b/server/README_deploy.md
@@ -1,0 +1,31 @@
+The server can be deployed to a kubernetes project.
+
+For instance, to use our test kubernetes project:
+```
+$ gcloud config set project test-mg-1006
+```
+
+You can then deploy, or re-deploy the server like so:
+
+```
+$ cd server
+$ kubectl create namespace burda-hackday
+$ export PROJECT_ID="$(gcloud config get-value project -q)"
+$ docker build -t gcr.io/${PROJECT_ID}/burda:murrayc-zeromq .
+$ gcloud docker -- push gcr.io/${PROJECT_ID}/burda:murrayc-zeromq
+$ kubectl apply -f deploy/burda.yaml
+```
+
+You can then discover the server's IP address like so:
+```
+$ kubectl get all --namespace=burda-hackday
+```
+
+You can test the server by running the test machine.py and consumer.py scripts in separate terminals.
+The machine.py script will send messages to the server, which the consumer.py script should receive:
+```
+$ python test/consumer.py
+...
+$ python test/machine.py
+```
+

--- a/server/deploy/burda.yaml
+++ b/server/deploy/burda.yaml
@@ -1,0 +1,62 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: null
+  generation: 1
+  labels:
+    run: burda
+  name: burda
+  namespace: burda-hackday
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: burda
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: burda
+    spec:
+      containers:
+      - image: gcr.io/test-mg-1006/burda:murrayc-zeromq
+        imagePullPolicy: IfNotPresent
+        name: burda
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        ports:
+        - containerPort: 5556
+        - containerPort: 5557
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: burda
+  namespace: burda-hackday
+spec:
+  ports:
+  - port: 5556
+    protocol: TCP
+    name: pull
+  - port: 5557
+    protocol: TCP
+    name: pub
+  selector:
+    run: burda
+  type: LoadBalancer

--- a/server/test/machine.py
+++ b/server/test/machine.py
@@ -13,7 +13,7 @@ def create_producer(host):
 
 
 def create_message(message_name, payload):
-    return '{{\n"{}": {}\n}}'.format(message_name, json.dumps(
+    return '{{\n"message_type": "{}",\n"body": {}\n}}'.format(message_name, json.dumps(
         {'machine_id': 4567, 'machine_type': 'M81', 'timestamp': time.time(), 'rfid': '0x1234567',
          'payload': payload}))
 

--- a/server/test/machine.py
+++ b/server/test/machine.py
@@ -13,7 +13,7 @@ def create_producer(host):
 
 
 def create_message(message_name, payload):
-    return '{} {}'.format(message_name, json.dumps(
+    return '{{\n"{}": {}\n}}'.format(message_name, json.dumps(
         {'machine_id': 4567, 'machine_type': 'M81', 'timestamp': time.time(), 'rfid': '0x1234567',
          'payload': payload}))
 

--- a/server/test/machine.py
+++ b/server/test/machine.py
@@ -120,6 +120,6 @@ def send_fake_machine_strength_measurment_flow(producer):
     producer.send(create_logout_message())
 
 
-producer = create_producer("tcp://35.195.199.160:5557")
+producer = create_producer("tcp://35.189.246.57:5557")
 send_fake_machine_training_flow(producer)
 send_fake_machine_strength_measurment_flow(producer)


### PR DESCRIPTION
This corrects the JSON message to be actual JSON, instead of a string that must be split to get a part that is JSON.

The Java and JavaScript client examples would still have to be updated. And we should probably change the message_type key to be a real key with the message type as a string value, to make filtering/handling easier.